### PR TITLE
Fix global

### DIFF
--- a/bin/colortape
+++ b/bin/colortape
@@ -2,7 +2,10 @@
 
 var path = require('path');
 var glob = require('glob');
-var test = require('tape');
+// To require the same tape module that is used by test files.
+var resolve = require('resolve');
+var tapePath = resolve.sync('tape', { basedir: process.cwd() });
+var test = require(tapePath);
 var ColorTape = require('..');
 var colorStream = new ColorTape();
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "BSD",
   "dependencies": {
     "glob": "^4.3.1",
+    "resolve": "^1.1.7",
     "tape": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "author": "Shuhei Kagawa <shuhei.kagawa@gmail.com>",
   "license": "BSD",
   "dependencies": {
-    "glob": "^4.3.1",
+    "glob": "^7.1.1",
     "resolve": "^1.1.7",
-    "tape": "^3.0.3"
+    "tape": ">= 3.0.0"
   }
 }


### PR DESCRIPTION
Fixes #2.

The error was happening on global install of `colortape`. When global cli is used for local test files, the cli and test files use different `tape` modules resulting strange output.

This PR makes the global cli to use the `tape` module used by local test files.